### PR TITLE
Added parsing constraints in signatures

### DIFF
--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/model/Signature.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/model/Signature.scala
@@ -1,25 +1,20 @@
 package org.virtuslab.inkuire.engine.model
 
-import org.virtuslab.inkuire.engine.model.TypeVariable
-
 case class Signature(
-  receiver: Type,
+  receiver: Option[Type],
   arguments: Seq[Type],
   result: Type,
   context: SignatureContext
 )
 
 case class SignatureContext(
-  vars: Set[TypeVariable],
-  constraints: Map[TypeVariable, Set[Type]]
+  vars: Set[String],
+  constraints: Map[String, Seq[Type]]
 )
 
 object SignatureContext {
 
   def empty: SignatureContext = {
-    SignatureContext(
-      Set.empty,
-      Map.empty
-    )
+    SignatureContext(Set.empty, Map.empty)
   }
 }

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/utils/syntax/AnyInkuireSyntax.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/utils/syntax/AnyInkuireSyntax.scala
@@ -5,5 +5,6 @@ trait AnyInkuireSyntax {
     def some: Option[A] = Some(v)
     def right[L]: Either[L, A] = Right(v)
     def left[R]: Either[A, R] = Left(v)
+    def whenOrElse(pred: Boolean)(msg: String): Either[String, A] = Option.when(pred)(v).toRight(msg)
   }
 }

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/BasicKotlinSignatureParserTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/BasicKotlinSignatureParserTest.scala
@@ -2,8 +2,8 @@ package org.virtuslab.inkuire.engine.parser
 
 import org.virtuslab.inkuire.engine.BaseInkuireTest
 import org.virtuslab.inkuire.engine.model.{Signature, SignatureContext}
-import org.virtuslab.inkuire.engine.model.SignatureContext
 import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
 
 class BasicKotlinSignatureParserTest extends BaseInkuireTest {
 
@@ -18,7 +18,7 @@ class BasicKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             "String".concreteType
           ),
@@ -40,7 +40,7 @@ class BasicKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             "String".concreteType
           ),
@@ -62,7 +62,7 @@ class BasicKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             "String".concreteType
           ),
@@ -85,7 +85,7 @@ class BasicKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             "String".concreteType
           ),
@@ -108,7 +108,7 @@ class BasicKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             "String".concreteType,
             "Long".concreteType,
@@ -133,7 +133,7 @@ class BasicKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq.empty,
           "Double".concreteType,
           SignatureContext.empty

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/BasicKotlinSignatureWithGenericsParserTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/BasicKotlinSignatureWithGenericsParserTest.scala
@@ -2,8 +2,8 @@ package org.virtuslab.inkuire.engine.parser
 
 import org.virtuslab.inkuire.engine.BaseInkuireTest
 import org.virtuslab.inkuire.engine.model.{GenericType, Signature, SignatureContext}
-import org.virtuslab.inkuire.engine.model.SignatureContext
 import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
 
 class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
 
@@ -18,7 +18,7 @@ class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "String".concreteType,
+          "String".concreteType.some,
           Seq("Int".concreteType),
           GenericType(
             "List".concreteType,
@@ -49,7 +49,7 @@ class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
             Seq(
               "Double".concreteType
             )
-          ),
+          ).some,
           Seq(
             "Int".concreteType
           ),
@@ -77,7 +77,7 @@ class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
             Seq(
               "Double".concreteType
             )
-          ),
+          ).some,
           Seq(
             "Int".concreteType
           ),
@@ -100,7 +100,7 @@ class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Float".concreteType,
+          "Float".concreteType.some,
           Seq(
             GenericType(
               "List".concreteType,
@@ -128,7 +128,7 @@ class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Float".concreteType,
+          "Float".concreteType.some,
           Seq(
             GenericType(
               "List".concreteType,
@@ -162,7 +162,7 @@ class BasicKotlinSignatureWithGenericsParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Float".concreteType,
+          "Float".concreteType.some,
           Seq(
             GenericType(
               "Map".concreteType,

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/GenericKotlinSignatureParserTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/GenericKotlinSignatureParserTest.scala
@@ -2,8 +2,8 @@ package org.virtuslab.inkuire.engine.parser
 
 import org.virtuslab.inkuire.engine.BaseInkuireTest
 import org.virtuslab.inkuire.engine.model.{GenericType, Signature, SignatureContext}
-import org.virtuslab.inkuire.engine.model.SignatureContext
 import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
 
 class GenericKotlinSignatureParserTest extends BaseInkuireTest {
 
@@ -18,14 +18,14 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Float".concreteType,
+          "Float".concreteType.some,
           Seq(
             "Int".concreteType
           ),
           "A".typeVariable,
           SignatureContext(
             Set(
-              "A".typeVariable
+              "A"
             ),
             Map.empty
           )
@@ -46,7 +46,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "B".typeVariable,
+          "B".typeVariable.some,
           Seq(
             GenericType(
               "List".concreteType,
@@ -58,7 +58,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
           "Double".concreteType,
           SignatureContext(
             Set(
-              "B".typeVariable
+              "B"
             ),
             Map.empty
           )
@@ -79,7 +79,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             GenericType(
               "A".typeVariable,
@@ -91,7 +91,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
           "Double".concreteType,
           SignatureContext(
             Set(
-              "A".typeVariable
+              "A"
             ),
             Map.empty
           )
@@ -112,7 +112,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             GenericType(
               "List".concreteType,
@@ -124,7 +124,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
           "Double".concreteType,
           SignatureContext(
             Set(
-              "XD".typeVariable
+              "XD"
             ),
             Map.empty
           )
@@ -145,7 +145,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Float".concreteType,
+          "Float".concreteType.some,
           Seq(
             GenericType(
               "List".concreteType,
@@ -167,7 +167,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
           "Double".concreteType,
           SignatureContext(
             Set(
-              "x".typeVariable
+              "x"
             ),
             Map.empty
           )
@@ -188,7 +188,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Float".concreteType,
+          "Float".concreteType.some,
           Seq(
             GenericType(
               "List".concreteType,
@@ -210,7 +210,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
           "Double".concreteType,
           SignatureContext(
             Set(
-              "x".typeVariable
+              "x"
             ),
             Map.empty
           )
@@ -236,7 +236,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
             Seq(
               "Int".concreteType
             )
-          ),
+          ).some,
           Seq(
             "B".typeVariable,
             "Float".concreteType
@@ -244,8 +244,8 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
           "Double".concreteType,
           SignatureContext(
             Set(
-              "A".typeVariable,
-              "B".typeVariable
+              "A",
+              "B"
             ),
             Map.empty
           )

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserConstraintsTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserConstraintsTest.scala
@@ -1,0 +1,214 @@
+package org.virtuslab.inkuire.engine.parser
+
+import org.virtuslab.inkuire.engine.BaseInkuireTest
+import org.virtuslab.inkuire.engine.model.{GenericType, Signature, SignatureContext}
+import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
+
+class KotlinSignatureParserConstraintsTest extends BaseInkuireTest {
+
+  it should "parse basic signature with a constraint" in {
+    //given
+    val str = "<A> A.() -> Int where A : Collection"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "A".typeVariable.some,
+          Seq.empty,
+          "Int".concreteType,
+          SignatureContext(
+            Set(
+              "A"
+            ),
+            Map(
+              "A" -> Seq("Collection".concreteType)
+            )
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with multiple constraints for one variable" in {
+    //given
+    val str = "<A> A.() -> Int where A : Collection, A : Iterable"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "A".typeVariable.some,
+          Seq.empty,
+          "Int".concreteType,
+          SignatureContext(
+            Set(
+              "A"
+            ),
+            Map(
+              "A" -> Seq(
+                "Collection".concreteType,
+                "Iterable".concreteType
+              )
+            )
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with multiple constraints" in {
+    //given
+    val str = "<A, B> A.(Int) -> B where A : Collection, A : Iterable, B : CharSequence"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "A".typeVariable.some,
+          Seq(
+            "Int".concreteType
+          ),
+          "B".typeVariable,
+          SignatureContext(
+            Set(
+              "B",
+              "A"
+            ),
+            Map(
+              "A" -> Seq(
+                "Collection".concreteType,
+                "Iterable".concreteType
+              ),
+              "B" -> Seq(
+                "CharSequence".concreteType
+              )
+            )
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with generic constraint" in {
+    //given
+    val str = "<A> A.(Int) -> String where A : Collection<Int>"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "A".typeVariable.some,
+          Seq(
+            "Int".concreteType
+          ),
+          "String".concreteType,
+          SignatureContext(
+            Set(
+              "A"
+            ),
+            Map(
+              "A" -> Seq(
+                GenericType(
+                  "Collection".concreteType,
+                  Seq(
+                    "Int".concreteType
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with constraints overkill" in {
+    //given
+    val str = "<A, B, C> A.(B<Int>) -> List<C> where A : Any, A : B<Float>, A : List<C>, B : Any?, B : Collection"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "A".typeVariable.some,
+          Seq(
+            GenericType(
+              "B".typeVariable,
+              Seq(
+                "Int".concreteType
+              )
+            )
+          ),
+          GenericType(
+            "List".concreteType,
+            Seq(
+              "C".typeVariable
+            )
+          ),
+          SignatureContext(
+            Set(
+              "A",
+              "B",
+              "C"
+            ),
+            Map(
+              "A" -> Seq(
+                "Any".concreteType,
+                GenericType(
+                  "B".typeVariable,
+                  Seq(
+                    "Float".concreteType
+                  )
+                ),
+                GenericType(
+                  "List".concreteType,
+                  Seq(
+                    "C".typeVariable
+                  )
+                )
+              ),
+              "B" -> Seq(
+                "Any".concreteType.?,
+                "Collection".concreteType
+              )
+            )
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "return error when a constraint is defined for a non variable type" in {
+    //given
+    val str = "A.(Int) -> String where A : Collection"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+
+    res should be(Symbol("left"))
+  }
+}

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserNoReceiverTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserNoReceiverTest.scala
@@ -1,0 +1,58 @@
+package org.virtuslab.inkuire.engine.parser
+
+import org.virtuslab.inkuire.engine.BaseInkuireTest
+import org.virtuslab.inkuire.engine.model.{GenericType, Signature, SignatureContext}
+import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
+
+class KotlinSignatureParserNoReceiverTest extends BaseInkuireTest {
+
+  it should "parse signature without receiver" in {
+    //given
+    val str = "() -> Double"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          None,
+          Seq.empty,
+          "Double".concreteType,
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]] (expectedRes)
+  }
+
+  it should "parse main" in {
+    //given
+    val str = "(Array<String>) -> Unit"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          None,
+          Seq(
+            GenericType(
+              "Array".concreteType,
+              Seq(
+                "String".concreteType
+              )
+            )
+          ),
+          "Unit".concreteType,
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]] (expectedRes)
+  }
+}

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserNullabilityTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserNullabilityTest.scala
@@ -2,8 +2,8 @@ package org.virtuslab.inkuire.engine.parser
 
 import org.virtuslab.inkuire.engine.BaseInkuireTest
 import org.virtuslab.inkuire.engine.model.{GenericType, Signature, SignatureContext}
-import org.virtuslab.inkuire.engine.model.SignatureContext
 import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
 
 class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
 
@@ -18,7 +18,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType.?,
+          "Int".concreteType.?.some,
           Seq.empty,
           "Double".concreteType,
           SignatureContext.empty
@@ -39,7 +39,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType.?,
+          "Int".concreteType.?.some,
           Seq.empty,
           "Double".concreteType,
           SignatureContext.empty
@@ -60,7 +60,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Int".concreteType,
+          "Int".concreteType.some,
           Seq(
             "String".concreteType.?,
             "Double".concreteType
@@ -84,7 +84,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          "Short".concreteType,
+          "Short".concreteType.some,
           Seq(
             "Double".concreteType
           ),
@@ -117,7 +117,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
             Seq(
               "Short".concreteType
             )
-          ),
+          ).some,
           Seq(
             "Double".concreteType
           ),
@@ -145,7 +145,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
             Seq(
               "Short".concreteType.?
             )
-          ),
+          ).some,
           Seq(
             "Double".concreteType
           ),
@@ -173,14 +173,14 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
             Seq(
               "Short".concreteType
             )
-          ),
+          ).some,
           Seq(
             "Double".concreteType
           ),
           "A".typeVariable.?,
           SignatureContext(
             Set(
-              "A".typeVariable
+              "A"
             ),
             Map.empty
           )
@@ -206,7 +206,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
             Seq(
               "Short".concreteType
             )
-          ),
+          ).some,
           Seq(
             "Double".concreteType
           ),
@@ -218,7 +218,7 @@ class KotlinSignatureParserNullabilityTest extends BaseInkuireTest {
           ),
           SignatureContext(
             Set(
-              "A".typeVariable
+              "A"
             ),
             Map.empty
           )

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/service/ExactMatchServiceTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/service/ExactMatchServiceTest.scala
@@ -4,6 +4,7 @@ import org.virtuslab.inkuire.engine.BaseInkuireTest
 import org.virtuslab.inkuire.engine.model.{ExternalSignature, GenericType, InkuireDb, Signature, SignatureContext}
 import org.virtuslab.inkuire.engine.model.Type._
 import org.virtuslab.inkuire.engine.service.ExactMatchServiceTest.Fixture
+import org.virtuslab.inkuire.engine.utils.syntax._
 
 class ExactMatchServiceTest extends BaseInkuireTest {
 
@@ -57,13 +58,30 @@ class ExactMatchServiceTest extends BaseInkuireTest {
     //then
     res should matchTo[Seq[ExternalSignature]] (Seq(rangeExternalSignature))
   }
+
+  it should "match signature without receiver" in new Fixture {
+    //given
+    val exactMatchService = new ExactMatchService(
+      InkuireDb(
+        Seq(
+          mainExternalSignature
+        ),
+        Map.empty
+      )
+    )
+    //when
+    val res: Seq[ExternalSignature] = exactMatchService |??| mainSignature
+
+    //then
+    res should matchTo[Seq[ExternalSignature]] (Seq(mainExternalSignature))
+  }
 }
 
 object ExactMatchServiceTest {
   trait Fixture {
 
     val equalsSignature: Signature = Signature(
-      "Int".concreteType,
+      "Int".concreteType.some,
       Seq(
         "Int".concreteType
       ),
@@ -77,7 +95,7 @@ object ExactMatchServiceTest {
     )
 
     val toStringSignature: Signature = Signature(
-      "Int".concreteType,
+      "Int".concreteType.some,
       Seq.empty,
       "String".concreteType,
       SignatureContext.empty
@@ -89,7 +107,7 @@ object ExactMatchServiceTest {
     )
 
     val rangeSignature: Signature = Signature(
-      "Long".concreteType,
+      "Long".concreteType.some,
       Seq(
         "Long".concreteType
       ),
@@ -105,6 +123,25 @@ object ExactMatchServiceTest {
       rangeSignature,
       "range",
       "/Long/range"
+    )
+
+    val mainSignature: Signature = Signature(
+      None,
+      Seq(
+        GenericType(
+          "Array".concreteType,
+          Seq(
+            "String".concreteType
+          )
+        )
+      ),
+      "Unit".concreteType,
+      SignatureContext.empty
+    )
+    val mainExternalSignature: ExternalSignature = ExternalSignature(
+      mainSignature,
+      "main",
+      "/Main/main"
     )
   }
 }


### PR DESCRIPTION
Pls check if the cases in tests are correct and if they are extensive enough (in context of use cases coverage)
EDIT:
Also made receivers optional, so signature like `(Array<String>) -> Unit` is now a valid syntax.