### PR TITLE
Added parsing function types and further signature validation

### DIFF
--- a/inkuire-engine/build.gradle.kts
+++ b/inkuire-engine/build.gradle.kts
@@ -25,11 +25,16 @@ dependencies{
     implementation("org.typelevel:cats-core_$scalaVersion:2.1.1")
     implementation("org.typelevel:cats-effect_$scalaVersion:2.1.1")
     implementation("org.typelevel:cats-mtl-core_$scalaVersion:0.7.1")
-    implementation("org.typelevel:mouse_$scalaVersion:0.25")
 
     implementation("com.softwaremill.quicklens:quicklens_$scalaVersion:1.5.0")
     implementation("com.softwaremill.diffx:diffx-core_$scalaVersion:0.3.28")
     implementation("com.softwaremill.diffx:diffx-scalatest_$scalaVersion:0.3.28")
 
     implementation("io.scalaland:chimney_$scalaVersion:0.5.1")
+}
+
+task("runCli", JavaExec::class) {
+    main = "org.virtuslab.inkuire.engine.cli.Main"
+    classpath = sourceSets["main"].runtimeClasspath
+    standardInput = System.`in`
 }

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/cli/Main.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/cli/Main.scala
@@ -47,17 +47,15 @@ object Main extends App with IOHelpers {
   }
 
   def handleCommands: Engine[Unit] = {
-    StateT.get[IO, Env] >>= { env: Env =>
-      IO {
-        println(s"inkuire [${env.dbPath}]> ")
-        readLine()
-      }.liftApp >>= { command: String =>
-        if (command.toLowerCase == "exit") {
-          IO.unit.liftApp
-        } else {
-          handleCommand(command) >>
-            handleCommands
-        }
+    IO {
+      print(s"inkuire> ")
+      readLine()
+    }.liftApp >>= { command: String =>
+      if (command.toLowerCase == "exit") {
+        IO { println("bye") }.liftApp
+      } else {
+        handleCommand(command) >>
+          handleCommands
       }
     }
   }

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/model/Type.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/model/Type.scala
@@ -4,7 +4,6 @@ import com.softwaremill.quicklens._
 import io.scalaland.chimney.dsl._
 
 trait Type {
-  def name: String
   def asVariable: Type
   def asConcrete: Type
   def nullable: Boolean
@@ -37,8 +36,6 @@ case class GenericType(
   params: Seq[Type]
 ) extends Type {
 
-  override def name: String = base.name
-
   override def asVariable: Type = this.modify(_.base).using(_.asVariable)
 
   override def asConcrete: Type = this.modify(_.base).using(_.asConcrete)
@@ -55,6 +52,19 @@ case class TypeVariable(
   override def asVariable: Type = this
 
   override def asConcrete: Type = this.transformInto[ConcreteType]
+
+  override def ? : Type = this.modify(_.nullable).setTo(true)
+}
+case class FunctionType(
+  receiver: Option[Type],
+  args: Seq[Type],
+  result: Type,
+  nullable: Boolean = false
+) extends Type {
+
+  override def asVariable: Type = throw new RuntimeException("Operation not allowed!")
+
+  override def asConcrete: Type = this
 
   override def ? : Type = this.modify(_.nullable).setTo(true)
 }

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/utils/syntax/AnyInkuireSyntax.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/utils/syntax/AnyInkuireSyntax.scala
@@ -5,6 +5,5 @@ trait AnyInkuireSyntax {
     def some: Option[A] = Some(v)
     def right[L]: Either[L, A] = Right(v)
     def left[R]: Either[A, R] = Left(v)
-    def whenOrElse(pred: Boolean)(msg: String): Either[String, A] = Option.when(pred)(v).toRight(msg)
   }
 }

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/GenericKotlinSignatureParserTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/GenericKotlinSignatureParserTest.scala
@@ -68,39 +68,6 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     res should matchTo[Either[String, Signature]] (expectedRes)
   }
 
-  it should "parse signature with type variable as base type in generic" in {
-    //given
-    val str = "<A> Int.(A<Byte>)->Double"
-
-    //when
-    val res = KotlinSignatureParser.parse(str)
-
-    //then
-    val expectedRes =
-      Right(
-        Signature(
-          "Int".concreteType.some,
-          Seq(
-            GenericType(
-              "A".typeVariable,
-              Seq(
-                "Byte".concreteType
-              )
-            )
-          ),
-          "Double".concreteType,
-          SignatureContext(
-            Set(
-              "A"
-            ),
-            Map.empty
-          )
-        )
-      )
-
-    res should matchTo[Either[String, Signature]] (expectedRes)
-  }
-
   it should "parse signature with type variable as parameter type in generic" in {
     //given
     val str = "<XD> Int.(List<XD>)-> Double"
@@ -177,52 +144,9 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     res should matchTo[Either[String, Signature]] (expectedRes)
   }
 
-  it should "parse signature with type variable in the middle of deeply nested parameter types" in {
-    //given
-    val str = "<x> Float.(List<x<Set<Float>>>)-> Double"
-
-    //when
-    val res = KotlinSignatureParser.parse(str)
-
-    //then
-    val expectedRes =
-      Right(
-        Signature(
-          "Float".concreteType.some,
-          Seq(
-            GenericType(
-              "List".concreteType,
-              Seq(
-                GenericType(
-                  "x".typeVariable,
-                  Seq(
-                    GenericType(
-                      "Set".concreteType,
-                      Seq(
-                        "Float".concreteType
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          ),
-          "Double".concreteType,
-          SignatureContext(
-            Set(
-              "x"
-            ),
-            Map.empty
-          )
-        )
-      )
-
-    res should matchTo[Either[String, Signature]] (expectedRes)
-  }
-
   it should "parse signature with multiple type variables" in {
     //given
-    val str = "<A, B> A<Int>.(B, Float)-> Double"
+    val str = "<A, B> A.(B, Float)-> Double"
 
     //when
     val res = KotlinSignatureParser.parse(str)
@@ -231,12 +155,7 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
     val expectedRes =
       Right(
         Signature(
-          GenericType(
-            "A".typeVariable,
-            Seq(
-              "Int".concreteType
-            )
-          ).some,
+          "A".typeVariable.some,
           Seq(
             "B".typeVariable,
             "Float".concreteType
@@ -253,5 +172,17 @@ class GenericKotlinSignatureParserTest extends BaseInkuireTest {
       )
 
     res should matchTo[Either[String, Signature]] (expectedRes)
+  }
+
+  it should "return error when type arguments are used for type parameters" in {
+    //given
+    val str = "<A> A<String>.(Int) -> String"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+
+    res should be(Symbol("left"))
   }
 }

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotilnSignatureParserFunctionTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotilnSignatureParserFunctionTest.scala
@@ -1,0 +1,166 @@
+package org.virtuslab.inkuire.engine.parser
+
+import org.virtuslab.inkuire.engine.BaseInkuireTest
+import org.virtuslab.inkuire.engine.model.{FunctionType, Signature, SignatureContext}
+import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
+
+class KotilnSignatureParserFunctionTest extends BaseInkuireTest {
+
+  it should "parse signature with a function receiver in parentheses" in {
+    //given
+    val str = "((Float) -> Double).(String)->Int"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          FunctionType(
+            None,
+            Seq(
+              "Float".concreteType
+            ),
+            "Double".concreteType
+          ).some,
+          Seq(
+            "String".concreteType
+          ),
+          "Int".concreteType,
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with a nullable function receiver in parentheses" in {
+    //given
+    val str = "(()->Int)?.() -> Unit"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          FunctionType(
+            None,
+            Seq.empty,
+            "Int".concreteType
+          ).?.some,
+          Seq.empty,
+          "Unit".concreteType,
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with a function result" in {
+    //given
+    val str = "Long . (String) -> (Float)->Double"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "Long".concreteType.some,
+          Seq(
+            "String".concreteType
+          ),
+        FunctionType(
+          None,
+          Seq(
+            "Float".concreteType
+          ),
+          "Double".concreteType
+        ),
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with a nested function args" in {
+    //given
+    val str = "Long.(Int.(Float.() -> Long) -> Unit, Double) -> Float"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "Long".concreteType.some,
+          Seq(
+            FunctionType(
+              "Int".concreteType.some,
+              Seq(
+                FunctionType(
+                  "Float".concreteType.some,
+                  Seq.empty,
+                  "Long".concreteType
+                )
+              ),
+              "Unit".concreteType
+            ),
+            "Double".concreteType
+          ),
+          "Float".concreteType,
+          SignatureContext.empty
+        )
+      )
+
+    res should equal(expectedRes)
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with piped functions as return types" in {
+    //given
+    val str = "Long.(String) -> (Float) -> Int.() -> Double.(Float) -> Unit"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "Long".concreteType.some,
+          Seq(
+            "String".concreteType
+          ),
+          FunctionType(
+            None,
+            Seq(
+              "Float".concreteType
+            ),
+            FunctionType(
+              "Int".concreteType.some,
+              Seq.empty,
+              FunctionType(
+                "Double".concreteType.some,
+                Seq(
+                  "Float".concreteType
+                ),
+                "Unit".concreteType
+              )
+            )
+          ),
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+}

--- a/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserParenthesesFeverTest.scala
+++ b/inkuire-engine/src/test/scala/org/virtuslab/inkuire/engine/parser/KotlinSignatureParserParenthesesFeverTest.scala
@@ -1,0 +1,135 @@
+package org.virtuslab.inkuire.engine.parser
+
+import org.virtuslab.inkuire.engine.BaseInkuireTest
+import org.virtuslab.inkuire.engine.model.{FunctionType, GenericType, Signature, SignatureContext}
+import org.virtuslab.inkuire.engine.model.Type._
+import org.virtuslab.inkuire.engine.utils.syntax._
+
+class KotlinSignatureParserParenthesesFeverTest extends BaseInkuireTest {
+
+  it should "parse basic signature with many unnecessary parentheses" in {
+    //given
+    val str = "(Int).((String), Double) -> (Unit)"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "Int".concreteType.some,
+          Seq(
+            "String".concreteType,
+            "Double".concreteType
+          ),
+          "Unit".concreteType,
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse generic signature with many unnecessary parentheses" in {
+    //given
+    val str = "<A> (((A?))?).( (((String) ) ), Double?) -> (Array<((A))>)"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "A".typeVariable.?.some,
+          Seq(
+            "String".concreteType,
+            "Double".concreteType.?
+          ),
+          GenericType(
+            "Array".concreteType,
+            Seq(
+              "A".typeVariable
+            )
+          ),
+          SignatureContext(
+            Set(
+              "A"
+            ),
+            Map.empty
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature with function type and many unnecessary parentheses" in {
+    //given
+    val str = "( (((String) ).(Byte) -> (((String)))?  ), Double? ) -> (Array<((Short))>?)"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          None,
+          Seq(
+            FunctionType(
+              "String".concreteType.some,
+              Seq(
+                "Byte".concreteType
+              ),
+              "String".concreteType.?
+            ),
+            "Double".concreteType.?
+          ),
+          GenericType(
+            "Array".concreteType.?,
+            Seq(
+              "Short".concreteType
+            )
+          ),
+          SignatureContext.empty
+        )
+      )
+
+    res should matchTo[Either[String, Signature]](expectedRes)
+  }
+
+  it should "parse signature in parentheses" in {
+    //given
+    val str = "((<B>B.(List<Byte>)->Double))"
+
+    //when
+    val res = KotlinSignatureParser.parse(str)
+
+    //then
+    val expectedRes =
+      Right(
+        Signature(
+          "B".typeVariable.some,
+          Seq(
+            GenericType(
+              "List".concreteType,
+              Seq(
+                "Byte".concreteType
+              )
+            )
+          ),
+          "Double".concreteType,
+          SignatureContext(
+            Set(
+              "B"
+            ),
+            Map.empty
+          )
+        )
+      )
+
+    res should matchTo[Either[String, Signature]] (expectedRes)
+  }
+}


### PR DESCRIPTION
Changes:
- added support for parsing functions ex. `(() -> String)-> Unit`
- using type variables as base types in generics is no longer a valid syntax
- Refactored validation (a bit)
- added support for some badly formatted signatures (mostly unnecessary parentheses)