### PR TITLE
Ability to pass config to engine with pureconfig

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -21,7 +21,7 @@ align {
 docstrings = JavaDoc
 
 rewrite {
-  rules = [SortImports, RedundantBraces]
+  rules = [SortImports]
   redundantBraces.maxLines = 1
 }
 

--- a/inkuire-engine/build.gradle.kts
+++ b/inkuire-engine/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation("io.scalaland:chimney_$scalaVersion:0.5.1")
     implementation("org.scala-lang.modules:scala-parser-combinators_$scalaVersion:1.1.2")
     implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.github.pureconfig:pureconfig_$scalaVersion:0.14.0")
 
     val http4sVersion = "0.21.0"
 

--- a/inkuire-engine/src/main/resources/application.conf
+++ b/inkuire-engine/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+port = 8080
+address = localhost
+db-paths = []
+ancestry-graph-paths = []

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/Main.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/Main.scala
@@ -1,6 +1,7 @@
 package org.virtuslab.inkuire.engine
 
 import org.virtuslab.inkuire.engine.cli.Cli
+import org.virtuslab.inkuire.engine.config.PureConfigReader
 import org.virtuslab.inkuire.engine.http.HttpServer
 import org.virtuslab.inkuire.engine.model.Engine.Env
 import org.virtuslab.inkuire.engine.model._
@@ -18,10 +19,8 @@ object Main extends App {
 
   configReader
     .readConfig(args)
-    .toOption
     .flatMap { config: AppConfig =>
       in.readInput(config)
-        .toOption
         .semiflatMap { db: InkuireDb =>
           out
             .serveOutput()
@@ -30,7 +29,7 @@ object Main extends App {
             )
         }
     }
-    .fold(println("Oooooh man, bad luck. Inkuire encountered an unexpected error :/"))(identity)
+    .fold(str => println(s"Oooooh man, bad luck. Inkuire encountered an unexpected error. Caused by $str"), identity)
     .unsafeRunSync()
 
 }

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/cli/Cli.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/cli/Cli.scala
@@ -77,7 +77,7 @@ class Cli extends InputHandler with OutputHandler with ConfigReader with IOHelpe
   override def readInput(appConfig: AppConfig): EitherT[IO, String, InkuireDb] = {
     InkuireDb
       .read(
-        appConfig.bdPaths.toList.map(path            => toURL(path.path)),
+        appConfig.dbPaths.toList.map(path            => toURL(path.path)),
         appConfig.ancestryGraphPaths.toList.map(path => toURL(path.path))
       )
       .traverse(value => IO { value })
@@ -87,7 +87,7 @@ class Cli extends InputHandler with OutputHandler with ConfigReader with IOHelpe
 
   override def readConfig(args: Seq[String]): EitherT[IO, String, AppConfig] = {
     parseArgs(AppParam.parseCliOption)(args.toList)
-      .map(AppConfig.create)
+      .flatMap(AppConfig.create)
       .pure[Id]
       .fmap(config => new EitherT(IO(config)))
   }

--- a/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/config/PureConfigReader.scala
+++ b/inkuire-engine/src/main/scala/org/virtuslab/inkuire/engine/config/PureConfigReader.scala
@@ -1,0 +1,18 @@
+package org.virtuslab.inkuire.engine.config
+
+import cats.data.EitherT
+import cats.effect.IO
+import org.virtuslab.inkuire.engine.api.ConfigReader
+import org.virtuslab.inkuire.engine.model.AppConfig
+import pureconfig.ConfigSource
+import pureconfig._
+import pureconfig.generic.auto._
+import cats.implicits._
+
+class PureConfigReader extends ConfigReader {
+  override def readConfig(args: Seq[String]): EitherT[IO, String, AppConfig] = {
+    EitherT {
+      IO { ConfigSource.default.load[AppConfig].leftMap(_.prettyPrint()) }
+    }
+  }
+}


### PR DESCRIPTION
You can now change `ConfigReader` strategy to `PureConfigReader` and write configuration in `application.conf`