### PR TITLE
Fix packages names not to break scaladoc generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
 val scala213 = "2.13.8"
-val scala3 = "3.1.1"
+val scala3 = "3.1.3"
 
 val orgSettings = Seq(
   organization := "org.virtuslab",

--- a/engine/src/main/scala/org/virtuslab/inkuire/engine/impl/model/scala302/InkuireDb.scala
+++ b/engine/src/main/scala/org/virtuslab/inkuire/engine/impl/model/scala302/InkuireDb.scala
@@ -1,4 +1,4 @@
-package org.virtuslab.inkuire.engine.impl.model.`scala-3.0.2`
+package org.virtuslab.inkuire.engine.impl.model.scala302
 
 import io.circe._
 import io.circe.generic.auto._

--- a/engine/src/main/scala/org/virtuslab/inkuire/engine/impl/model/scala310/InkuireDb.scala
+++ b/engine/src/main/scala/org/virtuslab/inkuire/engine/impl/model/scala310/InkuireDb.scala
@@ -1,4 +1,4 @@
-package org.virtuslab.inkuire.engine.impl.model.`scala-3.1.0`
+package org.virtuslab.inkuire.engine.impl.model.scala310
 
 import io.circe._
 import io.circe.generic.auto._

--- a/engine/src/main/scala/org/virtuslab/inkuire/engine/impl/service/EngineModelSerializers.scala
+++ b/engine/src/main/scala/org/virtuslab/inkuire/engine/impl/service/EngineModelSerializers.scala
@@ -57,6 +57,6 @@ object EngineModelSerializers {
   def deserialize(str: String): Either[String, InkuireDb] =
     decode[InkuireDb](str)
       .fold(l => Left(l.toString), Right.apply)
-      .orElse(`scala-3.0.2`.InkuireDb.deserialize(str))
-      .orElse(`scala-3.1.0`.InkuireDb.deserialize(str))
+      .orElse(scala302.InkuireDb.deserialize(str))
+      .orElse(scala310.InkuireDb.deserialize(str))
 }


### PR DESCRIPTION
Apparently, Scaladoc for Scala 3 really doesn't like packages with weird names in backticks e.g. `scala-3.0.2`.
I feel like those mistakes shouldn't happen in a repo developed by all top3 Scaladoc contributors :sweat_smile: 